### PR TITLE
arguments changing is now warning & no exception raised

### DIFF
--- a/ddoitranslatormodule/BaseFunction.py
+++ b/ddoitranslatormodule/BaseFunction.py
@@ -84,7 +84,7 @@ class TranslatorModuleFunction:
         args_diff = cls._diff_args(initial_args, args)
 
         if args_diff:
-            logger.warning(f"Args changed after pre-condition!")
+            logger.warning(f"Args changed after pre-condition: {args_diff}")
 #             raise DDOIArgumentsChangedException(f"Args changed after pre-condition")
 
 
@@ -102,7 +102,7 @@ class TranslatorModuleFunction:
         args_diff = cls._diff_args(initial_args, args)
 
         if args_diff:
-            logger.warning(f"Args changed after perform!")
+            logger.warning(f"Args changed after perform: {args_diff}")
 #             raise DDOIArgumentsChangedException(f"Args changed after perform")
         
 
@@ -120,7 +120,7 @@ class TranslatorModuleFunction:
         args_diff = cls._diff_args(initial_args, args)
 
         if args_diff:
-            logger.warning(f"Args changed after post-condition!")
+            logger.warning(f"Args changed after post-condition: {args_diff}")
 #             raise DDOIArgumentsChangedException(f"Args changed after post-condition")
         
         return return_value

--- a/ddoitranslatormodule/BaseFunction.py
+++ b/ddoitranslatormodule/BaseFunction.py
@@ -84,8 +84,8 @@ class TranslatorModuleFunction:
         args_diff = cls._diff_args(initial_args, args)
 
         if args_diff:
-            logger.error(f"Args changed after pre-condition!")
-            raise DDOIArgumentsChangedException(f"Args changed after pre-condition")
+            logger.warning(f"Args changed after pre-condition!")
+#             raise DDOIArgumentsChangedException(f"Args changed after pre-condition")
 
 
         ###########
@@ -102,8 +102,8 @@ class TranslatorModuleFunction:
         args_diff = cls._diff_args(initial_args, args)
 
         if args_diff:
-            logger.error(f"Args changed after perform!")
-            raise DDOIArgumentsChangedException(f"Args changed after pre-condition")
+            logger.warning(f"Args changed after perform!")
+#             raise DDOIArgumentsChangedException(f"Args changed after perform")
         
 
         ##################
@@ -120,8 +120,8 @@ class TranslatorModuleFunction:
         args_diff = cls._diff_args(initial_args, args)
 
         if args_diff:
-            logger.error(f"Args changed after post-condition!")
-            raise DDOIArgumentsChangedException(f"Args changed after pre-condition")
+            logger.warning(f"Args changed after post-condition!")
+#             raise DDOIArgumentsChangedException(f"Args changed after post-condition")
         
         return return_value
     

--- a/ddoitranslatormodule/BaseFunction.py
+++ b/ddoitranslatormodule/BaseFunction.py
@@ -84,7 +84,9 @@ class TranslatorModuleFunction:
         args_diff = cls._diff_args(initial_args, args)
 
         if args_diff:
-            logger.warning(f"Args changed after pre-condition: {args_diff}")
+            logger.debug(f"Args changed after pre-condition")
+            logger.debug(f"Before: {initial_args}")
+            logger.debug(f"After: {args}")
 #             raise DDOIArgumentsChangedException(f"Args changed after pre-condition")
 
 
@@ -102,7 +104,9 @@ class TranslatorModuleFunction:
         args_diff = cls._diff_args(initial_args, args)
 
         if args_diff:
-            logger.warning(f"Args changed after perform: {args_diff}")
+            logger.debug(f"Args changed after perform")
+            logger.debug(f"Before: {initial_args}")
+            logger.debug(f"After: {args}")
 #             raise DDOIArgumentsChangedException(f"Args changed after perform")
         
 
@@ -120,7 +124,9 @@ class TranslatorModuleFunction:
         args_diff = cls._diff_args(initial_args, args)
 
         if args_diff:
-            logger.warning(f"Args changed after post-condition: {args_diff}")
+            logger.debug(f"Args changed after post-condition")
+            logger.debug(f"Before: {initial_args}")
+            logger.debug(f"After: {args}")
 #             raise DDOIArgumentsChangedException(f"Args changed after post-condition")
         
         return return_value

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -191,7 +191,7 @@ def create_logger():
     utnow = datetime.utcnow()
     date = utnow-timedelta(days=1)
     date_str = date.strftime('%Y%b%d').lower()
-    logdir = Path(f"/home/dsibld/logs/{date_str}/cli_logs")
+    logdir = Path(f"/s/sdata1701/KPFTranslator_logs/{date_str}/cli_logs")
     if logdir.exists() is False:
         logdir.mkdir(parents=True)
     LogFileName = logdir / 'cli_interface.log'

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import sys
 import importlib
 import traceback
@@ -191,7 +192,13 @@ def create_logger():
     utnow = datetime.utcnow()
     date = utnow-timedelta(days=1)
     date_str = date.strftime('%Y%b%d').lower()
-    logdir = Path(f"/s/sdata1701/KPFTranslator_logs/{date_str}/cli_logs")
+
+    hostname = socket.gethostname()
+    if hostname.lower() in ['kpf', 'vm-kpf', 'kpffiuserver', 'kpfserver']:
+        logdir = Path(f"/s/sdata1701/KPFTranslator_logs/{date_str}/cli_logs")
+    elif hostname.lower() in ['vm-ddoiserverbuild', 'vm-ddoiserver']:
+        logdir = Path(f"/home/dsibld/logs/{date_str}/cli_logs")
+
     if logdir.exists() is False:
         logdir.mkdir(parents=True)
     LogFileName = logdir / 'cli_interface.log'

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -336,8 +336,6 @@ def main(table_loc, args):
         parser = function.add_cmdline_args(parser)
         logger.debug("Parsing function arguments...")
         try:
-            print(type(parsed_func_args))
-            print(type(vars(parser.parse_args(final_args))))
             parsed_func_args.update(vars(parser.parse_args(final_args)))
             logger.debug("Parsed.")
         except ArgumentError as e:

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -327,22 +327,24 @@ def main(table_loc, args):
                 logger.error(
                     "Filetype is not supported. I understand [.yml, .json]")
                 return
+        else:
+            parsed_func_args = {}
         
-        else: # If there isn't a file, parse from the command line
-            
-            # Build an ArgumentParser and attach the function's arguments
-            parser = ArgumentParser(add_help=False)
-            logger.debug(f"Adding CLI args to parser")
-            parser = function.add_cmdline_args(parser)
-            logger.debug("Parsing function arguments...")
-            try:
-                parsed_func_args = parser.parse_args(final_args)
-                logger.debug("Parsed.")
-            except ArgumentError as e:
-                logger.error("Failed to parse arguments!")
-                logger.error(e)
-                logger.error(traceback.format_exc())
-                sys.exit(1)
+        # Build an ArgumentParser and attach the function's arguments
+        parser = ArgumentParser(add_help=False)
+        logger.debug(f"Adding CLI args to parser")
+        parser = function.add_cmdline_args(parser)
+        logger.debug("Parsing function arguments...")
+        try:
+            print(type(parsed_func_args))
+            print(type(vars(parser.parse_args(final_args))))
+            parsed_func_args.update(vars(parser.parse_args(final_args)))
+            logger.debug("Parsed.")
+        except ArgumentError as e:
+            logger.error("Failed to parse arguments!")
+            logger.error(e)
+            logger.error(traceback.format_exc())
+            sys.exit(1)
 
 
         if parsed_args.dry_run:


### PR DESCRIPTION
* Arguments changing results in just a log message, not user visible effects in the log and no exception raised.
* The `cli_interface.py` code now handles both file input (e.g. reading YAML file) and argparse command line args in the individual translator functions.  If there is a conflict, the command line values take precedence.
* The `cli_interface.py` logdir is now set after checking hostname so that it fully supports running on KPF machines.

I believe this makes KPFs version `1-0-1` fully functional and retires all of the critical to do items at the bottom of [2022-11-14+Meeting+notes](https://keckobservatory.atlassian.net/wiki/spaces/DSI/pages/1462534160/2022-11-14+Meeting+notes)
