### PR TITLE
Handle hostname with full .keck.hawaii.edu

### DIFF
--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -194,6 +194,8 @@ def create_logger():
     date_str = date.strftime('%Y%b%d').lower()
 
     hostname = socket.gethostname()
+    if hostname[-16:] == '.keck.hawaii.edu':
+        hostname = hostname[:-16]
     if hostname.lower() in ['kpf', 'vm-kpf', 'kpffiuserver', 'kpfserver']:
         logdir = Path(f"/s/sdata1701/KPFTranslator_logs/{date_str}/cli_logs")
     elif hostname.lower() in ['vm-ddoiserverbuild', 'vm-ddoiserver']:

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -1,4 +1,5 @@
 import os
+import stat
 import socket
 import sys
 import importlib
@@ -203,6 +204,23 @@ def create_logger():
 
     if logdir.exists() is False:
         logdir.mkdir(parents=True)
+    if not os.stat(logdir.parent).st_mode & stat.S_IWOTH:
+#         print(f"Fixing permissions on {logdir.parent}")
+        # Try to set permissions on the date directory
+        # necessary because the mode input to mkdir is modified by umask
+        try:
+            os.chmod(logdir.parent, 0o777)
+        except OSError as e:
+            pass
+    if not os.stat(logdir).st_mode & stat.S_IWOTH:
+#         print(f"Fixing permissions on {logdir}")
+        # Try to set permissions on the cli_logs directory
+        # necessary because the mode input to mkdir is modified by umask
+        try:
+            os.chmod(logdir, 0o777)
+        except OSError as e:
+            pass
+
     LogFileName = logdir / 'cli_interface.log'
     LogFileHandler = logging.FileHandler(LogFileName)
     LogFileHandler.setLevel(logging.DEBUG)


### PR DESCRIPTION
Handle the case where `socket.gethostname()` returns a string with the ".keck.hawaii.edu" extension.

Now also fixed log file permissions.  This fix supersedes pull request 7 as it handles more cases.