### PR TITLE
Fix log file permissions

### DIFF
--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -17,20 +17,6 @@ from ddoitranslatormodule.ddoiexceptions.DDOIExceptions import DDOITranslatorMod
 from ddoitranslatormodule.BaseFunction import TranslatorModuleFunction
 
 
-def send_email(email_contents,
-               to='kpf_info@keck.hawaii.edu',
-               frm='kpf_info@keck.hawaii.edu',
-               subj='Alert',
-               ):
-    msg = MIMEText(email_contents)
-    msg['To'] = to
-    msg['From'] = frm
-    msg['Subject'] = subj
-    s = smtplib.SMTP('relay.keck.hawaii.edu')
-    s.send_message(msg)
-    s.quit()
-
-
 class LinkingTable():
     """Class storing the contents of a linking table
     """
@@ -215,41 +201,26 @@ def create_logger():
         logdir = Path(f"/home/dsibld/logs/{date_str}/cli_logs")
     if logdir.exists() is False:
         logdir.mkdir(mode=0o777, parents=True)
-        # Try to examine permissions on log directory
-        logdir_permissions = oct(os.stat(logdir).st_mode)[-3:]
-        if logdir_permissions != '777':
-            try:
-                msg = [f'Failed to create logdir with proper permissions:',
-                       f'{logdir}',
-                       f'Permissions: {logdir_permissions}']
-                send_email('\n'.join(msg),
-                           to='jwalawender@keck.hawaii.edu',
-                           frm='kpf_info@keck.hawaii.edu',
-                           subj='Permissions for logdir are bad')
-            except Exception as email_err:
-                log.error(f'Sending email failed')
-                log.error(email_err)
-
+        # Try to set permissions on the date directory
+        try:
+            os.chmod(logdir.parent, 0o777)
+        except OSError as e:
+            pass
+        # Try to set permissions on the cli_logs directory
+        try:
+            os.chmod(logdir, 0o777)
+        except OSError as e:
+            pass
     LogFileName = logdir / 'cli_interface.log'
     LogFileHandler = logging.FileHandler(LogFileName)
     LogFileHandler.setLevel(logging.DEBUG)
     LogFileHandler.setFormatter(LogFormat)
     log.addHandler(LogFileHandler)
-
     # Try to change permissions on file in case they are bad
     try:
         os.chmod(LogFileName, 0o666)
     except OSError as e:
-        try:
-            msg = [f'{type(e)}',
-                   f'{traceback.format_exc()}']
-            send_email('\n'.join(msg),
-                       to='jwalawender@keck.hawaii.edu',
-                       frm='kpf_info@keck.hawaii.edu',
-                       subj=f'chmod for {LogFileName} failed')
-        except Exception as email_err:
-            log.error(f'Sending email failed')
-            log.error(email_err)
+        pass
 
     return log
 

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -240,7 +240,7 @@ def create_logger():
     # Try to change permissions on file in case they are bad
     try:
         os.chmod(LogFileName, 0o666)
-    except OSError:
+    except OSError as e:
         try:
             msg = [f'{type(e)}',
                    f'{traceback_text}']

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -24,7 +24,7 @@ def send_email(email_contents,
                ):
     msg = MIMEText(email_contents)
     msg['To'] = to
-    msg['From'] = from
+    msg['From'] = frm
     msg['Subject'] = subj
     s = smtplib.SMTP('relay.keck.hawaii.edu')
     s.send_message(msg)

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -243,7 +243,7 @@ def create_logger():
     except OSError as e:
         try:
             msg = [f'{type(e)}',
-                   f'{traceback_text}']
+                   f'{traceback.format_exc()}']
             send_email('\n'.join(msg),
                        to='jwalawender@keck.hawaii.edu',
                        frm='kpf_info@keck.hawaii.edu',

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -9,11 +9,26 @@ from argparse import ArgumentParser, ArgumentError
 from typing import Dict, List, Tuple
 import logging
 from datetime import datetime, timedelta
-
+import smtplib
+from email.mime.text import MIMEText
 import yaml
 
 from ddoitranslatormodule.ddoiexceptions.DDOIExceptions import DDOITranslatorModuleNotFoundException
 from ddoitranslatormodule.BaseFunction import TranslatorModuleFunction
+
+
+def send_email(email_contents,
+               to='kpf_info@keck.hawaii.edu',
+               frm='kpf_info@keck.hawaii.edu',
+               subj='Alert',
+               ):
+    msg = MIMEText(email_contents)
+    msg['To'] = to
+    msg['From'] = from
+    msg['Subject'] = subj
+    s = smtplib.SMTP('relay.keck.hawaii.edu')
+    s.send_message(msg)
+    s.quit()
 
 
 class LinkingTable():
@@ -198,19 +213,45 @@ def create_logger():
         logdir = Path(f"/s/sdata1701/KPFTranslator_logs/{date_str}/cli_logs")
     elif hostname.lower() in ['vm-ddoiserverbuild', 'vm-ddoiserver']:
         logdir = Path(f"/home/dsibld/logs/{date_str}/cli_logs")
-
     if logdir.exists() is False:
         logdir.mkdir(mode=0o777, parents=True)
+
+    # Try to examine permissions on log directory
+    logdir_permissions = oct(os.stat(logdir).st_mode)[-3:]
+    if logdir_permissions != '777':
+        try:
+            msg = [f'Failed to set permissions:',
+                   f'{logdir}',
+                   f'Permissions: {logdir_permissions}']
+            send_email('\n'.join(msg),
+                       to='jwalawender@keck.hawaii.edu',
+                       frm='kpf_info@keck.hawaii.edu',
+                       subj='Permissions for logdir are bad')
+        except Exception as email_err:
+            log.error(f'Sending email failed')
+            log.error(email_err)
+
     LogFileName = logdir / 'cli_interface.log'
     LogFileHandler = logging.FileHandler(LogFileName)
     LogFileHandler.setLevel(logging.DEBUG)
     LogFileHandler.setFormatter(LogFormat)
     log.addHandler(LogFileHandler)
-    # Try to change permissions in case they are bad
+
+    # Try to change permissions on file in case they are bad
     try:
         os.chmod(LogFileName, 0o666)
     except OSError:
-        pass
+        try:
+            msg = [f'{type(e)}',
+                   f'{traceback_text}']
+            send_email('\n'.join(msg),
+                       to='jwalawender@keck.hawaii.edu',
+                       frm='kpf_info@keck.hawaii.edu',
+                       subj=f'chmod for {LogFileName} failed')
+        except Exception as email_err:
+            log.error(f'Sending email failed')
+            log.error(email_err)
+
     return log
 
 def main(table_loc, args):

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -200,12 +200,17 @@ def create_logger():
         logdir = Path(f"/home/dsibld/logs/{date_str}/cli_logs")
 
     if logdir.exists() is False:
-        logdir.mkdir(parents=True)
+        logdir.mkdir(mode=0o777, parents=True)
     LogFileName = logdir / 'cli_interface.log'
     LogFileHandler = logging.FileHandler(LogFileName)
     LogFileHandler.setLevel(logging.DEBUG)
     LogFileHandler.setFormatter(LogFormat)
     log.addHandler(LogFileHandler)
+    # Try to change permissions in case they are bad
+    try:
+        os.chmod(LogFileName, 0o666)
+    except OSError:
+        pass
     return log
 
 def main(table_loc, args):

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -215,21 +215,20 @@ def create_logger():
         logdir = Path(f"/home/dsibld/logs/{date_str}/cli_logs")
     if logdir.exists() is False:
         logdir.mkdir(mode=0o777, parents=True)
-
-    # Try to examine permissions on log directory
-    logdir_permissions = oct(os.stat(logdir).st_mode)[-3:]
-    if logdir_permissions != '777':
-        try:
-            msg = [f'Failed to set permissions:',
-                   f'{logdir}',
-                   f'Permissions: {logdir_permissions}']
-            send_email('\n'.join(msg),
-                       to='jwalawender@keck.hawaii.edu',
-                       frm='kpf_info@keck.hawaii.edu',
-                       subj='Permissions for logdir are bad')
-        except Exception as email_err:
-            log.error(f'Sending email failed')
-            log.error(email_err)
+        # Try to examine permissions on log directory
+        logdir_permissions = oct(os.stat(logdir).st_mode)[-3:]
+        if logdir_permissions != '777':
+            try:
+                msg = [f'Failed to create logdir with proper permissions:',
+                       f'{logdir}',
+                       f'Permissions: {logdir_permissions}']
+                send_email('\n'.join(msg),
+                           to='jwalawender@keck.hawaii.edu',
+                           frm='kpf_info@keck.hawaii.edu',
+                           subj='Permissions for logdir are bad')
+            except Exception as email_err:
+                log.error(f'Sending email failed')
+                log.error(email_err)
 
     LogFileName = logdir / 'cli_interface.log'
     LogFileHandler = logging.FileHandler(LogFileName)

--- a/ddoitranslatormodule/cli_interface.py
+++ b/ddoitranslatormodule/cli_interface.py
@@ -202,11 +202,13 @@ def create_logger():
     if logdir.exists() is False:
         logdir.mkdir(mode=0o777, parents=True)
         # Try to set permissions on the date directory
+        # necessary because the mode input to mkdir is modified by umask
         try:
             os.chmod(logdir.parent, 0o777)
         except OSError as e:
             pass
         # Try to set permissions on the cli_logs directory
+        # necessary because the mode input to mkdir is modified by umask
         try:
             os.chmod(logdir, 0o777)
         except OSError as e:


### PR DESCRIPTION
KPF has been using this branch (args_change_is_warning).  It looks like that got merged in to main at some point (we're still on the branch on KPF).

This change (currently untested, but will test soon) aims to address [K1-34761](https://www.keck.hawaii.edu/software/ndlog/webForm/ndSecure/ndweb.php?log=k1n&ticket=34761)

On the KPF machines, I'm calling this v1.0.2